### PR TITLE
Demonstrate seeking and scanning

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -99,9 +99,8 @@ fn index(db: State<Arc<DB>>) -> String {
 fn random(db: State<Arc<DB>>) -> Markup {
     let mut iter = db.iterator(IteratorMode::Start);
 
-
     html! {
-        h1 "Jeff May?:"
+        h2 "Projects"
         ol {
             @for (k, v) in iter {
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ fn random(db: State<Arc<DB>>) -> Markup {
                 );
 
                 li (file_info.path)
-            }
+        }
     }
 }
 }
@@ -144,3 +144,14 @@ fn random(db: State<Arc<DB>>) -> Markup {
 //     println!("Saw {:?} {:?}", key, value);
 // }
 // ```
+// write batches!
+// use rocksdb::{DB, WriteBatch};
+//
+// let db = DB::open_default("path/for/rocksdb/storage1").unwrap();
+// {
+//     let mut batch = WriteBatch::default();
+//     batch.put(b"my key", b"my value");
+//     batch.put(b"key2", b"value2");
+//     batch.put(b"key3", b"value3");
+//     db.write(batch); // Atomically commits the batch
+// }

--- a/src/project.rs
+++ b/src/project.rs
@@ -40,6 +40,7 @@ pub struct FileInfo {
 }
 
 impl FileInfo {
+    /// from_path constructs a FileInfo by inspecting the contents of the file at path.
     pub fn from_path(path: &Path) -> Result<FileInfo, io::Error> {
         println!("GETTING ONE FILE NOW {:?}", path);
         let file = File::open(path)?;
@@ -68,6 +69,7 @@ impl FileInfo {
         Ok(file_info)
     }
 
+    // TODO: this is silly.
     pub fn blank() -> FileInfo {
         FileInfo{ path: String::from("error"), lines: 0, extension: String::new() }
     }

--- a/tests/db_test.rs
+++ b/tests/db_test.rs
@@ -14,7 +14,7 @@ use std::time;
 use chrono::prelude::*;
 use tempdir::TempDir;
 use bincode::{deserialize, serialize, Infinite};
-use std::path::PathBuf;
+use std::path::{PathBuf, Path};
 use coded::*;
 use coded::db::Key;
 
@@ -28,9 +28,9 @@ fn test_sortable_key() {
     let nine_eleven = make_key!(Utc.ymd(2001, 09, 11));
 
     // make 3 private data structures that indicate their expected order via id field
-    let _val1 = SomeValue { id: 1 };
-    let _val2 = SomeValue { id: 2 };
-    let _val3 = SomeValue { id: 3 };
+    let _val1 = Thing { id: 1 };
+    let _val2 = Thing { id: 2 };
+    let _val3 = Thing { id: 3 };
 
     let first = oct_rev.clone();
 
@@ -51,20 +51,91 @@ fn test_sortable_key() {
     let db_vec1 = iter.next().unwrap();
     // note we access second field of tuple here with .1
     // the & gets us into the Box
-    let decoded1: SomeValue = deserialize(&db_vec1.1[..]).unwrap();
+    let decoded1: Thing = deserialize(&db_vec1.1[..]).unwrap();
 
     let db_vec2 = iter.next().unwrap();
-    let decoded2: SomeValue = deserialize(&db_vec2.1[..]).unwrap();
+    let decoded2: Thing = deserialize(&db_vec2.1[..]).unwrap();
 
     let db_vec3 = iter.next().unwrap();
-    let decoded3: SomeValue = deserialize(&db_vec3.1[..]).unwrap();
+    let decoded3: Thing = deserialize(&db_vec3.1[..]).unwrap();
 
     assert_eq!(decoded1.id, 1);
     assert_eq!(decoded2.id, 2);
     assert_eq!(decoded3.id, 3);
 }
 
+#[test]
+fn test_aggregation() {
+    let mut db = DB::open_default(TempDir::new("test").unwrap()).unwrap();
+
+    // Make keys with this structure
+    // projects!{proj_path}!{batch_ts}!{path}
+
+    // With values like this structure
+    // { path, line_count }
+
+    // Write these to the database and seek through them to aggregate results.
+
+    // procedure:
+    // 1. write a batch of line counts for two distinct files at Time A
+    // 2. write another batch at Time B
+    // 3. given only a project dir path (what config gives us), compute
+    //    the growth/delta of both files over the history
+
+    // for example, dir might be our configured path from coded.toml
+    let dir = "/tmp";
+
+    let time_a = Utc.ymd(2010, 04, 20);
+    let time_b = Utc.ymd(2011, 04, 20);
+
+    let src_a = project::FileInfo{ path: String::from("/tmp/main.c"), lines: 100, extension: String::from("c")};
+    let header_a = project::FileInfo{ path: String::from("/tmp/main.h"), lines: 50, extension: String::from("h")};
+
+    let src_b = project::FileInfo{ path: String::from("/tmp/main.c"), lines: 110, extension: String::from("c")};
+    let header_b = project::FileInfo{ path: String::from("/tmp/main.h"), lines: 40, extension: String::from("h")};
+
+    let src_a_key = make_key!("projects!", dir, "!", time_a, "!", src_a.path.clone());
+    let header_a_key = make_key!("projects!", dir, "!", time_a, "!", header_a.path.clone());
+
+    let src_b_key = make_key!("projects!", dir, "!", time_b, "!", src_b.path.clone());
+    let header_b_key = make_key!("projects!", dir, "!", time_b, "!", header_b.path.clone());
+
+    let writes = [
+        (src_a_key, src_a),
+        (header_a_key, header_a),
+        (src_b_key, src_b),
+        (header_b_key, header_b),
+    ];
+
+    for &(ref k, ref v) in writes.iter() {
+        let encoded = serialize(&v, Infinite).unwrap();
+        db.put(k.0.as_slice(), encoded.as_slice()).unwrap();
+    }
+    // we can "re-use" this iterator
+    let mut iter = db.iterator(IteratorMode::Start);
+
+    // expected keys in the db: 4
+    let all_keys: i32 = iter.map(|kv| 1 ).sum();
+    assert_eq!(all_keys, 4);
+
+    // We do an explicit seek to Time A, but we know that it's still the first key in the db
+    iter = db.iterator(IteratorMode::From(
+        make_key!("projects!", dir, "!", time_a).0.as_slice(), Direction::Forward));
+
+    let a_and_b_keys: i32 = iter.map(|kv| 1 ).sum();
+    assert_eq!(a_and_b_keys, 4);
+
+    iter = db.iterator(IteratorMode::From(
+        make_key!("projects!", dir, "!", time_b).0.as_slice(), Direction::Forward));
+
+    let b_keys: i32 = iter.map(|kv| 1 ).sum();
+    assert_eq!(b_keys, 2);
+
+    // deltas: main.c +10  main.h -10
+
+}
+
 #[derive(Serialize, Deserialize)]
-struct SomeValue {
+struct Thing {
     id: i32
 }


### PR DESCRIPTION
Keys made with make_key can have partial keys reconstructed with
make_key as well. This lets us seek to a prefix.